### PR TITLE
Add endpoint to get property analytics for a property

### DIFF
--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -41,11 +41,11 @@ class PropertyController extends Controller
         return new JsonResponse($response, Response::HTTP_CREATED);
     }
 
-    public function addUpdatePropertyAnalytic(Request $request, int $property_id)
+    public function addUpdatePropertyAnalytics(Request $request, int $propertyId): JsonResponse
     {
         $data = $request->all();
 
-        $data['property_id'] = $property_id;
+        $data['property_id'] = $propertyId;
 
         $validator = Validator::make($data, [
             'analytic_type_id' => 'required',
@@ -58,6 +58,13 @@ class PropertyController extends Controller
         }
 
         $response = $this->propertyAnalyticRepository->updateOrCreate($data);
+
+        return new JsonResponse($response->toArray(), Response::HTTP_OK);
+    }
+
+    public function getPropertyAnalytics(int $propertyId): JsonResponse
+    {
+        $response = $this->propertyRepository->findPropertyAnalyticsByPropertyId($propertyId);
 
         return new JsonResponse($response->toArray(), Response::HTTP_OK);
     }

--- a/app/Repositories/PropertyAnalyticRepository.php
+++ b/app/Repositories/PropertyAnalyticRepository.php
@@ -3,32 +3,21 @@
 namespace App\Repositories;
 
 use App\Models\PropertyAnalytic;
-use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 
 class PropertyAnalyticRepository extends BaseRepository implements PropertyAnalyticRepositoryInterface
 {
-
-    /**
-     * UserRepository constructor.
-     *
-     * @param Property $model
-     */
     public function __construct(PropertyAnalytic $model)
     {
         parent::__construct($model);
     }
 
-    /**
-     * @return Model
-     */
     public function updateOrCreate(array $attributes): Model
     {
         $updateResult = $this->model
             ->where('property_id', $attributes['property_id'])
             ->where('analytic_type_id', $attributes['analytic_type_id'])
             ->update(['value' => $attributes['value']]);
-
 
         if($updateResult) {
             return $this->model
@@ -38,13 +27,5 @@ class PropertyAnalyticRepository extends BaseRepository implements PropertyAnaly
                     ->first();
         }
         return $this->model->create($attributes);
-    }
-
-    /**
-     * @return Collection
-     */
-    public function all(): Collection
-    {
-        return $this->model->all();
     }
 }

--- a/app/Repositories/PropertyAnalyticRepositoryInterface.php
+++ b/app/Repositories/PropertyAnalyticRepositoryInterface.php
@@ -7,5 +7,4 @@ use Illuminate\Support\Collection;
 interface PropertyAnalyticRepositoryInterface
 {
     public function updateOrCreate(array $attributes): Model;
-    public function all(): Collection;
 }

--- a/app/Repositories/PropertyRepository.php
+++ b/app/Repositories/PropertyRepository.php
@@ -8,30 +8,19 @@ use Illuminate\Database\Eloquent\Model;
 
 class PropertyRepository extends BaseRepository implements PropertyRepositoryInterface
 {
-
-    /**
-     * UserRepository constructor.
-     *
-     * @param Property $model
-     */
     public function __construct(Property $model)
     {
         parent::__construct($model);
     }
 
-    /**
-     * @return Model
-     */
     public function create(array $attributes): Model
     {
         return $this->model->create($attributes);
     }
 
-    /**
-     * @return Collection
-     */
-    public function all(): Collection
+
+    public function findPropertyAnalyticsByPropertyId(int $propertyId): Collection
     {
-        return $this->model->all();
+        return $this->model->find($propertyId)->propertyAnalytics()->get();
     }
 }

--- a/app/Repositories/PropertyRepositoryInterface.php
+++ b/app/Repositories/PropertyRepositoryInterface.php
@@ -7,5 +7,5 @@ use Illuminate\Support\Collection;
 interface PropertyRepositoryInterface
 {
     public function create(array $attributes): Model;
-    public function all(): Collection;
+    public function findPropertyAnalyticsByPropertyId(int $propertyId): Collection;
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,5 +16,7 @@ use Illuminate\Support\Facades\Route;
 
 Route::post('properties', 'PropertyController@addProperty')
     ->name('api.add-property');
-Route::put('properties/{property_id}/property-analytic', 'PropertyController@addUpdatePropertyAnalytic')
+Route::put('properties/{property_id}/property-analytics', 'PropertyController@addUpdatePropertyAnalytics')
+    ->name('api.add-update-property-analytic');
+Route::get('properties/{property_id}/property-analytics', 'PropertyController@getPropertyAnalytics')
     ->name('api.add-update-property-analytic');

--- a/tests/Feature/Http/Controllers/PropertyControllerTest.php
+++ b/tests/Feature/Http/Controllers/PropertyControllerTest.php
@@ -59,7 +59,7 @@ class PropertyControllerTest extends TestCase
     public function testAddPropertyAnalyticSuccess()
     {
         $response = $this->putJson(
-            env('APP_URL').'/api/properties/1/property-analytic',
+            env('APP_URL').'/api/properties/1/property-analytics',
             [
                 'analytic_type_id' => 1,
                 'value' => 11
@@ -79,7 +79,7 @@ class PropertyControllerTest extends TestCase
     public function testAddPropertyAnalyticReturnsError()
     {
         $response = $this->putJson(
-            env('APP_URL').'/api/properties/1/property-analytic',
+            env('APP_URL').'/api/properties/1/property-analytics',
             [
                 'value' => 11
             ]
@@ -95,5 +95,21 @@ class PropertyControllerTest extends TestCase
                 ],
             ]
         );
+    }
+
+    public function testGetPropertAnalyticsByPropertyId()
+    {
+        $response = $this->get(
+            env('APP_URL').'/api/properties/12/property-analytics'
+        );
+
+        $response
+            ->assertStatus(200)
+            ->assertJson([
+                    [
+                        'property_id' => 12,
+                    ],
+                ]
+            );
     }
 }

--- a/tests/Unit/Http/Controllers/PropertyControllerTest.php
+++ b/tests/Unit/Http/Controllers/PropertyControllerTest.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\PropertyController;
 use App\Models\PropertyAnalytic;
 use App\Repositories\PropertyRepository;
 use App\Repositories\PropertyAnalyticRepository;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Request;
 use Tests\TestCase;
 use Mockery;
@@ -142,7 +143,7 @@ class PropertyControllerTest extends TestCase
         );
 
         $property_id = 1;
-        $response = $controller->addUpdatePropertyAnalytic($requestMock, $property_id);
+        $response = $controller->addUpdatePropertyAnalytics($requestMock, $property_id);
 
 
         $data = json_decode(
@@ -184,7 +185,7 @@ class PropertyControllerTest extends TestCase
         );
 
         $property_id = 1;
-        $response = $controller->addUpdatePropertyAnalytic($requestMock, $property_id);
+        $response = $controller->addUpdatePropertyAnalytics($requestMock, $property_id);
 
 
         $data = json_decode(
@@ -193,5 +194,60 @@ class PropertyControllerTest extends TestCase
         );
 
         $this->assertEquals($expected, $data);
+    }
+
+    public function testGetPropertyAnalyticsByPropertId()
+    {
+        $expected = collect([
+            [
+                'id' => 76,
+                'value' => '29',
+                'created_at' => '2020-07-07T20:38:00.000000Z',
+                'updated_at' => '2020-07-07T20:38:00.000000Z',
+                'property_id' => 76,
+                'analytic_type_id' => 1,
+            ],
+            [
+                'id' => 151,
+                'value' => '301',
+                'created_at' => '2020-07-07T20:38:00.000000Z',
+                'updated_at' => '2020-07-07T20:38:00.000000Z',
+                'property_id' => 76,
+                'analytic_type_id' => 2,
+            ],
+            [
+                'id' => 205,
+                'value' => '2.290435341',
+                'created_at' => '2020-07-07T20:38:00.000000Z',
+                'updated_at' => '2020-07-07T20:38:00.000000Z',
+                'property_id' => 76,
+                'analytic_type_id' => 3,
+            ],
+        ]);
+
+
+        $propertyRepositoryMock = Mockery::mock(PropertyRepository::class);
+        $propertyRepositoryMock->shouldReceive('findPropertyAnalyticsByPropertyId')
+            ->withAnyArgs()
+            ->once()
+            ->andReturn($expected);
+
+        $propertyAnalyticRepositoryMock = Mockery::mock(PropertyAnalyticRepository::class);
+
+        # When
+        $controller = new PropertyController(
+            $propertyRepositoryMock,
+            $propertyAnalyticRepositoryMock
+        );
+        $propertyId = 76;
+        $response = $controller->getPropertyAnalytics($propertyId);
+
+        $data = json_decode(
+            $response->getContent(),
+            true
+        );
+
+        # Assert
+        $this->assertEquals($expected->all(), $data);
     }
 }

--- a/tests/Unit/Repositories/PropertyAnalyticRepository.php
+++ b/tests/Unit/Repositories/PropertyAnalyticRepository.php
@@ -4,13 +4,12 @@ namespace Tests\Unit\Repositories;
 
 use App\Models\PropertyAnalytic;
 use App\Repositories\PropertyAnalyticRepository;
-use Illuminate\Support\Collection;
 use Tests\TestCase;
 use Mockery;
 
 class PropertyAnalyticRepositoryTest extends TestCase
 {
-    public function testUpdateOrCreateMethodForExisitingRecord()
+    public function testUpdateOrCreateMethodForExistingRecord()
     {
         $propertyModelMock = Mockery::mock(PropertyAnalytic::class);
         $propertyModelMock->shouldReceive('update')
@@ -20,11 +19,13 @@ class PropertyAnalyticRepositoryTest extends TestCase
 
         $propertyModelMock->shouldReceive('where')
             ->withAnyArgs()
-            ->times(4);
+            ->times(4)
+            ->andReturnSelf();;
 
         $propertyModelMock->shouldReceive('get')
             ->withAnyArgs()
-            ->times(1);
+            ->times(1)
+            ->andReturnSelf();;
 
         $propertyModelMock->shouldReceive('first')
             ->withAnyArgs()
@@ -32,7 +33,11 @@ class PropertyAnalyticRepositoryTest extends TestCase
             ->andReturnSelf();
 
         $repository = new PropertyAnalyticRepository($propertyModelMock);
-        $result = $repository->updateOrCreate([]);
+        $result = $repository->updateOrCreate([
+            'property_id' => 1,
+            'analytic_type_id' => 1,
+            'value' => '123'
+        ]);
 
         $this->assertInstanceOf(PropertyAnalytic::class, $result);
     }
@@ -43,11 +48,12 @@ class PropertyAnalyticRepositoryTest extends TestCase
         $propertyModelMock->shouldReceive('update')
             ->withAnyArgs()
             ->times(1)
-            ->andReturn(true);
+            ->andReturn(false);
 
         $propertyModelMock->shouldReceive('where')
             ->withAnyArgs()
-            ->times(2);
+            ->times(2)
+            ->andReturnSelf();
 
         $propertyModelMock->shouldReceive('create')
             ->withAnyArgs()
@@ -55,22 +61,12 @@ class PropertyAnalyticRepositoryTest extends TestCase
             ->andReturnSelf();
 
         $repository = new PropertyAnalyticRepository($propertyModelMock);
-        $result = $repository->updateOrCreate([]);
+        $result = $repository->updateOrCreate([
+            'property_id' => 1,
+            'analytic_type_id' => 1,
+            'value' => '123'
+        ]);
 
         $this->assertInstanceOf(PropertyAnalytic::class, $result);
-    }
-
-    public function testAllMethod()
-    {
-        $propertyModelMock = Mockery::mock(PropertyAnalytic::class);
-        $propertyModelMock->shouldReceive('all')
-            ->withAnyArgs()
-            ->times(1)
-            ->andReturns(new Collection());
-
-        $repository = new PropertyAnalyticRepository($propertyModelMock);
-        $result = $repository->all();
-
-        $this->assertInstanceOf(Collection::class, $result);
     }
 }

--- a/tests/Unit/Repositories/PropertyRepositoryTest.php
+++ b/tests/Unit/Repositories/PropertyRepositoryTest.php
@@ -38,4 +38,28 @@ class PropertyRepositoryTest extends TestCase
 
        $this->assertInstanceOf(Collection::class, $result);
     }
+
+    public function testfindPropertyAnalyticsByPropertyIdMethod()
+    {
+        $propertyModelMock = Mockery::mock(Property::class);
+
+        $propertyModelMock->shouldReceive('find')
+            ->withAnyArgs()
+            ->times(1)
+            ->andReturnSelf();
+        $propertyModelMock->shouldReceive('propertyAnalytics')
+            ->withAnyArgs()
+            ->times(1)
+            ->andReturnSelf();
+        $propertyModelMock->shouldReceive('get')
+            ->withAnyArgs()
+            ->times(1)
+            ->andReturn(new Collection());
+
+        $propertyId = 1;
+        $repository = new PropertyRepository($propertyModelMock);
+        $result = $repository->findPropertyAnalyticsByPropertyId($propertyId);
+
+        $this->assertInstanceOf(Collection::class, $result);
+    }
 }


### PR DESCRIPTION
URI:  /api/properties/{property_id}/property-analytics

Response :
`[
    {
        "id": 76,
        "value": "29",
        "created_at": "2020-07-07T20:38:00.000000Z",
        "updated_at": "2020-07-07T20:38:00.000000Z",
        "property_id": 76,
        "analytic_type_id": 1
    },
    {
        "id": 151,
        "value": "301",
        "created_at": "2020-07-07T20:38:00.000000Z",
        "updated_at": "2020-07-07T20:38:00.000000Z",
        "property_id": 76,
        "analytic_type_id": 2
    },
    {
        "id": 205,
        "value": "2.290435341",
        "created_at": "2020-07-07T20:38:01.000000Z",
        "updated_at": "2020-07-07T20:38:01.000000Z",
        "property_id": 76,
        "analytic_type_id": 3
    }
]`